### PR TITLE
Fix PHP 7.2 deprecated warning

### DIFF
--- a/core/core.php
+++ b/core/core.php
@@ -953,8 +953,12 @@ class wsBrokenLinkChecker {
         <th scope="row"><?php _e('Look for links in', 'broken-link-checker'); ?></th>
         <td>
     	<?php
+        function modules_uasort_callback($a, $b){
+            return strcasecmp($a["Name"], $b["Name"]);
+        }
+
     	if ( !empty($modules['container']) ){
-    		uasort($modules['container'], create_function('$a, $b', 'return strcasecmp($a["Name"], $b["Name"]);'));
+    		uasort($modules['container'], 'modules_uasort_callback');
     		$this->print_module_list($modules['container'], $this->conf->options);
     	}
     	?>

--- a/modules/checkers/http.php
+++ b/modules/checkers/http.php
@@ -144,10 +144,14 @@ class blcHttpCheckerBase extends blcChecker {
 		//TODO: Remove/fix this. Probably not a good idea to "fix" invalid URLs like that.
 		return preg_replace_callback(
 			'|[^a-z0-9\+\-\/\\#:.,;=?!&%@()$\|*~_]|i',
-            create_function('$str','return rawurlencode($str[0]);'),
+            'urlencodefix_replace_callback',
 			$url
 		);
 	}
+
+    function urlencodefix_replace_callback($str){
+        return rawurlencode($str[0]);
+    }
 
 }
 


### PR DESCRIPTION
This is a proper fix for PHP 7.2 deprecated create_function call that not breaks PHP 5.2 compatibility