### PR TITLE
Options table: stop autoloading the logs

### DIFF
--- a/includes/logger.php
+++ b/includes/logger.php
@@ -114,7 +114,7 @@ class blcCachedOptionLogger extends blcLogger {
 	}
 	
 	function save(){
-		update_option($this->option_name, $this->log);
+		update_option($this->option_name, $this->log, false);
 	}
 }
 


### PR DESCRIPTION
Fixes #78 

With this update the installations_log no longer has the autoload flag turned on
![Screenshot 2020-06-26 at 10 55 00](https://user-images.githubusercontent.com/367593/85845011-7ccf5d80-b79b-11ea-8412-dc404393615e.jpg)

This probably comes from the fact that the [add_option](https://developer.wordpress.org/reference/functions/add_option/) function defaults to setting the autoload to true, which can be easily missed. 